### PR TITLE
Add stub reporting module for tests

### DIFF
--- a/app/escriptorium/test_settings.py
+++ b/app/escriptorium/test_settings.py
@@ -3,7 +3,14 @@ import os.path
 import celery.app.trace
 from celery import signals
 
-from reporting.tasks import create_task_reporting
+# Import reporting hooks; fall back to local stub if the optional
+# ``reporting`` package is unavailable.
+try:
+    from reporting.tasks import create_task_reporting
+except ModuleNotFoundError:  # pragma: no cover - executed only when reporting missing
+    def create_task_reporting(*args, **kwargs):  # type: ignore[override]
+        """Fallback no-op used when reporting is not installed."""
+        pass
 
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True

--- a/app/reporting/__init__.py
+++ b/app/reporting/__init__.py
@@ -1,0 +1,4 @@
+"""Minimal reporting stub for tests."""
+
+# Provide minimal modules to satisfy imports during testing.
+from . import tasks, models  # noqa: F401

--- a/app/reporting/models.py
+++ b/app/reporting/models.py
@@ -1,0 +1,6 @@
+"""Stub models for reporting used in tests."""
+
+
+class TaskReport:
+    """Placeholder model used in tests."""
+    pass

--- a/app/reporting/tasks.py
+++ b/app/reporting/tasks.py
@@ -1,0 +1,8 @@
+"""Stub tasks for reporting used in tests."""
+
+def create_task_reporting(*args, **kwargs):
+    """Placeholder task for test environment.
+
+    Accepts arbitrary arguments and performs no action.
+    """
+    pass


### PR DESCRIPTION
## Summary
- provide minimal `reporting` package with stub models and tasks
- make test settings fall back to local reporting stub when optional module missing

## Testing
- `DJANGO_SETTINGS_MODULE=escriptorium.test_settings PYTHONPATH=apps pytest` *(fails: AppRegistryNotReady)*

------
https://chatgpt.com/codex/tasks/task_e_68c45371f6c88326987f7c68a396c212